### PR TITLE
docker-compose.ymlのスキーマバージョンを3.9に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 services:
     app:
         image: gotodo


### PR DESCRIPTION
docker-compose.ymlのスキーマバージョンを3から3.9に修正