### PR TITLE
DBが起動してからGoのサーバーが起動するように制御する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,14 @@ services:
             TODO_DB_PORT: 3306
             TODO_DB_USER: todo
             TODO_DB_PASSWORD: todo
-            TODO_DB_DATABASE: todo
+            TODO_DB_NAME: todo
         volumes:
             - .:/app
         ports:
             - '18000:8080'
+        depends_on:
+            todo-db:
+                condition: service_healthy
     todo-db:
         image: mysql:8.0.29
         platform: linux/amd64
@@ -32,5 +35,11 @@ services:
             - $PWD/_tools/mysql/conf.d:/etc/mysql/conf.d
         ports:
             - '33306:3306'
+        healthcheck:
+            test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+            start_period: 1m
+            interval: 10s
+            timeout: 5s
+            retries: 3
 volumes:
     todo-db-data:


### PR DESCRIPTION
MySQLのコンテナが起動完了する前にGoのHTTPサーバーがたちが上がってしまい、接続エラーになっていたので、docker-composeのdepends_onを使って起動順序を制御するように変更