### PR TITLE
構造体名にパッケージ名を含めるようにする

### DIFF
--- a/handler/add_task.go
+++ b/handler/add_task.go
@@ -9,12 +9,12 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-type AddTask struct {
+type AddTaskHandler struct {
 	Service   AddTaskService
 	Validator *validator.Validate
 }
 
-func (at *AddTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (at *AddTaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var b struct {
 		Title string `json:"title" validate:"required"`

--- a/handler/add_task_test.go
+++ b/handler/add_task_test.go
@@ -59,7 +59,7 @@ func TestAddTask(t *testing.T) {
 				}
 				return nil, errors.New("error from mock")
 			}
-			sut := AddTask{
+			sut := AddTaskHandler{
 				Service:   moq,
 				Validator: validator.New(),
 			}

--- a/handler/list_task.go
+++ b/handler/list_task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/takurooo/go-todo-app/entity"
 )
 
-type ListTask struct {
+type ListTaskHandler struct {
 	Service ListTasksService
 }
 
@@ -16,7 +16,7 @@ type task struct {
 	Status entity.TaskStatus `json:"status"`
 }
 
-func (lt *ListTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (lt *ListTaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	tasks, err := lt.Service.ListTasks(ctx)
 	if err != nil {

--- a/handler/list_task_test.go
+++ b/handler/list_task_test.go
@@ -61,7 +61,7 @@ func TestListTask(t *testing.T) {
 				}
 				return nil, errors.New("error from mock")
 			}
-			sut := ListTask{Service: moq}
+			sut := ListTaskHandler{Service: moq}
 			sut.ServeHTTP(w, r)
 
 			resp := w.Result()

--- a/handler/login.go
+++ b/handler/login.go
@@ -7,12 +7,12 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-type Login struct {
+type LoginHandler struct {
 	Service   LoginService
 	Validator *validator.Validate
 }
 
-func (l *Login) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (l *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var body struct {
 		UserName string `json:"user_name" validate:"required"`

--- a/handler/login_test.go
+++ b/handler/login_test.go
@@ -70,7 +70,7 @@ func TestLogin_ServeHTTP(t *testing.T) {
 			moq.LoginFunc = func(ctx context.Context, name, pw string) (string, error) {
 				return tt.moq.token, tt.moq.err
 			}
-			sut := Login{
+			sut := LoginHandler{
 				Service:   moq,
 				Validator: validator.New(),
 			}

--- a/handler/register_user.go
+++ b/handler/register_user.go
@@ -8,12 +8,12 @@ import (
 	"github.com/takurooo/go-todo-app/entity"
 )
 
-type RegisterUser struct {
+type RegisterUserHandler struct {
 	Service   RegisterUserService
 	Validator *validator.Validate
 }
 
-func (ru *RegisterUser) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (ru *RegisterUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var b struct {
 		Name     string `json:"name" validate:"required"`

--- a/mux.go
+++ b/mux.go
@@ -39,14 +39,14 @@ func NewMux(ctx context.Context, cfg *config.Config) (http.Handler, func(), erro
 		return nil, cleanup, err
 	}
 
-	ru := &handler.RegisterUser{
-		Service:   &service.RegisterUser{DB: db, Repo: &r},
+	ru := &handler.RegisterUserHandler{
+		Service:   &service.RegisterUserService{DB: db, Repo: &r},
 		Validator: v,
 	}
 	mux.Post("/register", ru.ServeHTTP)
 
-	l := &handler.Login{
-		Service: &service.Login{
+	l := &handler.LoginHandler{
+		Service: &service.LoginService{
 			DB:             db,
 			Repo:           &r,
 			TokenGenerator: jwter,
@@ -55,12 +55,12 @@ func NewMux(ctx context.Context, cfg *config.Config) (http.Handler, func(), erro
 	}
 	mux.Post("/login", l.ServeHTTP)
 
-	at := &handler.AddTask{
-		Service:   &service.AddTask{DB: db, Repo: &r},
+	at := &handler.AddTaskHandler{
+		Service:   &service.AddTaskService{DB: db, Repo: &r},
 		Validator: v,
 	}
-	lt := &handler.ListTask{
-		Service: &service.ListTask{DB: db, Repo: &r},
+	lt := &handler.ListTaskHandler{
+		Service: &service.ListTaskService{DB: db, Repo: &r},
 	}
 	mux.Route("/tasks", func(r chi.Router) {
 		r.Use(handler.AuthMiddleware(jwter))

--- a/service/add_task.go
+++ b/service/add_task.go
@@ -9,12 +9,12 @@ import (
 	"github.com/takurooo/go-todo-app/store"
 )
 
-type AddTask struct {
+type AddTaskService struct {
 	DB   store.Execer
 	Repo TaskAdder
 }
 
-func (a *AddTask) AddTask(ctx context.Context, title string) (*entity.Task, error) {
+func (a *AddTaskService) AddTask(ctx context.Context, title string) (*entity.Task, error) {
 	id, ok := auth.GetUserID(ctx)
 	if !ok {
 		return nil, fmt.Errorf("user_id not found")

--- a/service/list_task.go
+++ b/service/list_task.go
@@ -9,12 +9,12 @@ import (
 	"github.com/takurooo/go-todo-app/store"
 )
 
-type ListTask struct {
+type ListTaskService struct {
 	DB   store.Queryer
 	Repo TaskLister
 }
 
-func (l *ListTask) ListTasks(ctx context.Context) (entity.Tasks, error) {
+func (l *ListTaskService) ListTasks(ctx context.Context) (entity.Tasks, error) {
 	id, ok := auth.GetUserID(ctx)
 	if !ok {
 		return nil, fmt.Errorf("user_id not found")

--- a/service/login.go
+++ b/service/login.go
@@ -7,13 +7,13 @@ import (
 	"github.com/takurooo/go-todo-app/store"
 )
 
-type Login struct {
+type LoginService struct {
 	DB             store.Queryer
 	Repo           UserGetter
 	TokenGenerator TokenGenerator
 }
 
-func (l *Login) Login(ctx context.Context, name, pw string) (string, error) {
+func (l *LoginService) Login(ctx context.Context, name, pw string) (string, error) {
 	u, err := l.Repo.GetUser(ctx, l.DB, name)
 	if err != nil {
 		return "", fmt.Errorf("failed to list: %w", err)

--- a/service/register_user.go
+++ b/service/register_user.go
@@ -9,12 +9,12 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-type RegisterUser struct {
+type RegisterUserService struct {
 	DB   store.Execer
 	Repo UserRegister
 }
 
-func (r *RegisterUser) RegisterUser(
+func (r *RegisterUserService) RegisterUser(
 	ctx context.Context, name, password, role string,
 ) (*entity.User, error) {
 	pw, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)


### PR DESCRIPTION
構造体名にパッケージ名を含めるように変更。
パッケージ名を名前に含めるのは冗長だがコードの検索がやりにくかったのでパッケージ名を構造体に埋め込む。